### PR TITLE
Ujednolicilem konwencje do odwolywania sie do macierzy

### DIFF
--- a/source/IncidenceMatrix.cpp
+++ b/source/IncidenceMatrix.cpp
@@ -43,12 +43,12 @@ Graph &IncidenceMatrix::addVertex()
 
 Graph &IncidenceMatrix::addEdge(int firstVertex, int secondVertex)
 {
-    for (unsigned int i = 0; i < matrix.size(); ++i)
+    for (unsigned int row = 0; row < _n; ++row)
     {
-        if(i == firstVertex || i == secondVertex)
-            matrix[i].push_back(1);
+        if(row == firstVertex || row == secondVertex)
+            matrix[row].push_back(1);
         else
-            matrix[i].push_back(0);
+            matrix[row].push_back(0);
     }
 
     return *this;
@@ -91,24 +91,13 @@ Graph &IncidenceMatrix::convertFromList(AdjacencyList const &adjacencyList)
     auto list = adjacencyList.getList();
     _n = list.size();
     matrix.clear();
-
-    for (int i = 0; i < _n; ++i)
+    matrix.resize(_n);
+    for (int first = 0; first < _n; first++)
     {
-
-        for (auto edge : list[i])
+        for (int second : list[first])
         {
-            std::vector<int> column(_n);
-            column[i] = 1;
-            column[edge] = 1;
-            matrix.push_back(column);
-            for (auto it = list[edge].begin(); it != list[edge].end(); ++it)
-            {
-                if (*it == i)
-                {
-                    list[edge].erase(it);
-                    break;
-                }
-            }
+            std::cout<< first << " " << second <<std::endl;
+            addEdge(first, second);
         }
     }
     return *this;


### PR DESCRIPTION
_n w pewnym momencie wskazywało na liczbę krawędzi, a nie wierzchołków. Przez zmianę tego, trzeba było zmienić ciąg innych drobnych rzeczy. Wszystkie podstawowe niskopoziomowe funkcje powinny działać